### PR TITLE
Morale system

### DIFF
--- a/Subterfuge.Test/AgentTests.cs
+++ b/Subterfuge.Test/AgentTests.cs
@@ -19,7 +19,7 @@ namespace Subterfuge.Test
             {
                 Agent agent = agentType.Instantiate<Agent>();
 
-                Assert.IsTrue(agent.IsAlive);
+                Assert.IsTrue(agent.IsActive);
                 Assert.IsFalse(agent.IsActing);
                 Assert.IsFalse(agent.IsBlocked);
                 Assert.IsFalse(agent.IsProtected);
@@ -117,7 +117,7 @@ namespace Subterfuge.Test
             agent.Reset();
             Assert.IsFalse(agent.WasAttacked);
             Assert.IsFalse(agent.WasKilled);
-            Assert.IsFalse(agent.IsAlive);
+            Assert.IsFalse(agent.IsActive);
             Assert.IsNotNull(agent.Killer);
         }
 
@@ -152,7 +152,7 @@ namespace Subterfuge.Test
 
             agent.Attack(attacker);
             Assert.IsTrue(agent.WasAttacked);
-            Assert.IsTrue(agent.IsAlive);
+            Assert.IsTrue(agent.IsActive);
         }
 
         [Test]
@@ -193,14 +193,14 @@ namespace Subterfuge.Test
             agent.Protect(protector);
             agent.Attack(attacker);
             Assert.IsTrue(agent.WasAttacked);
-            Assert.IsTrue(agent.IsAlive);
+            Assert.IsTrue(agent.IsActive);
             Assert.IsNull(agent.Killer);
 
             agent.Reset();
 
             agent.Attack(attacker);
             Assert.IsTrue(agent.WasAttacked);
-            Assert.IsFalse(agent.IsAlive);
+            Assert.IsFalse(agent.IsActive);
             Assert.IsNotNull(agent.Killer);
             Assert.AreSame(attacker, agent.Killer);
         }
@@ -211,7 +211,7 @@ namespace Subterfuge.Test
             Agent agent = new Hacker();
 
             agent.Execute();
-            Assert.IsFalse(agent.IsAlive);
+            Assert.IsFalse(agent.IsActive);
             Assert.IsTrue(agent.WasKilled);
             Assert.IsNull(agent.Killer);
         }

--- a/Subterfuge.Test/GameServiceTests.cs
+++ b/Subterfuge.Test/GameServiceTests.cs
@@ -63,13 +63,13 @@ namespace Subterfuge.Test
 
             // Make sure the initial values make sense
             Assert.IsTrue(_game.Round > 1);
-            Assert.IsFalse(_game.Agents[nameof(Hacker)].IsAlive);
+            Assert.IsFalse(_game.Agents[nameof(Hacker)].IsActive);
 
             _game.Reset();
 
             // Make sure the game actually got reset
             Assert.AreEqual(1, _game.Round);
-            Assert.IsTrue(_game.Agents[nameof(Hacker)].IsAlive);
+            Assert.IsTrue(_game.Agents[nameof(Hacker)].IsActive);
         }
 
         [Test]
@@ -80,7 +80,7 @@ namespace Subterfuge.Test
 
             // Make sure that the values to be checked later are what they should be before the game starts
             Assert.IsFalse(_game.Agents.OrderedList.Any(a => a.WasFramed));
-            Assert.IsTrue(_game.Agents[nameof(Fabricator)].IsAlive);
+            Assert.IsTrue(_game.Agents[nameof(Fabricator)].IsActive);
             Assert.IsNull(_game.Agents[nameof(Fabricator)].Target);
 
             _game.PlayRound();
@@ -90,7 +90,7 @@ namespace Subterfuge.Test
 
             // Make sure that actions actually happened
             // If the Fabricator's target was framed, the Fabricator acted; if the Fabricator is dead, the Android acted
-            Assert.IsTrue(_game.Agents[nameof(Fabricator)].Target.WasFramed || !_game.Agents[nameof(Fabricator)].IsAlive);
+            Assert.IsTrue(_game.Agents[nameof(Fabricator)].Target.WasFramed || !_game.Agents[nameof(Fabricator)].IsActive);
         }
     }
 }

--- a/Subterfuge.Test/Helpers.cs
+++ b/Subterfuge.Test/Helpers.cs
@@ -20,7 +20,7 @@ namespace Subterfuge.Test
             killer.ActIfAble();
             Assert.IsTrue(killer.Target.WasAttacked);
             Assert.IsTrue(killer.Target.Visitors.Contains(killer.Codename));
-            Assert.IsTrue(killer.Target.IsAlive);
+            Assert.IsTrue(killer.Target.IsActive);
             killer.Target.Reset();
             killer.Reset();
 
@@ -30,7 +30,7 @@ namespace Subterfuge.Test
             killer.ActIfAble();
             Assert.IsTrue(killer.Target.WasAttacked);
             Assert.IsTrue(killer.Target.Visitors.Contains(killer.Codename));
-            Assert.IsFalse(killer.Target.IsAlive);
+            Assert.IsFalse(killer.Target.IsActive);
         }
 
         public static void TestProtectAction(Agent protector, GameService game, bool protectorShouldDie)
@@ -56,13 +56,13 @@ namespace Subterfuge.Test
 
             Assert.IsTrue(target.WasAttacked);
             Assert.IsFalse(target.WasKilled);
-            Assert.IsTrue(target.IsAlive);
+            Assert.IsTrue(target.IsActive);
             Assert.AreEqual(!protectorShouldDie, target.IsProtected);
             Assert.IsTrue(target.Visitors.Contains(protector.Codename));
 
             Assert.IsFalse(protector.WasAttacked);
             Assert.AreEqual(protectorShouldDie, protector.WasKilled);
-            Assert.AreEqual(!protectorShouldDie, protector.IsAlive);
+            Assert.AreEqual(!protectorShouldDie, protector.IsActive);
             Assert.IsTrue(protectorShouldDie ? protector.Killer == attacker : protector.Killer is null);
         }
 
@@ -133,19 +133,19 @@ namespace Subterfuge.Test
 
             Assert.IsFalse(target.Visitors.Contains(killer.Codename));
             Assert.IsFalse(target.WasAttacked);
-            Assert.IsTrue(target.IsAlive);
+            Assert.IsTrue(target.IsActive);
 
             Assert.IsFalse(blocker.Visitors.Contains(killer.Codename));
             if (shouldKill)
             {
                 Assert.AreSame(blocker, killer.Target);
-                Assert.IsFalse(blocker.IsAlive);
+                Assert.IsFalse(blocker.IsActive);
                 Assert.IsTrue(blocker.WasKilled);
                 Assert.AreSame(killer, blocker.Killer);
             }
             else
             {
-                Assert.IsTrue(blocker.IsAlive);
+                Assert.IsTrue(blocker.IsActive);
                 Assert.IsFalse(blocker.WasKilled);
                 Assert.IsNull(blocker.Killer);
             }

--- a/Subterfuge/AgentList.cs
+++ b/Subterfuge/AgentList.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Subterfuge.Agents;
 using Subterfuge.Enums;
 

--- a/Subterfuge/Agents/Agent.cs
+++ b/Subterfuge/Agents/Agent.cs
@@ -197,7 +197,7 @@ namespace Subterfuge.Agents
         /// <summary>
         /// Reset this agent for a new round.
         /// </summary>
-        public void Reset()
+        public virtual void Reset()
         {
             IsActing = false;
             WasFramed = false;

--- a/Subterfuge/Agents/Agent.cs
+++ b/Subterfuge/Agents/Agent.cs
@@ -30,9 +30,9 @@ namespace Subterfuge.Agents
         /// </summary>
         public abstract bool RequiresTarget { get; }
         /// <summary>
-        /// Whether this agent is still alive.
+        /// Whether this agent is still in the game. This will be set to false if an agent dies or deserts.
         /// </summary>
-        public bool IsAlive { get; protected set; }
+        public bool IsActive { get; protected set; }
         /// <summary>
         /// Whether this agent is acting this round.
         /// </summary>
@@ -76,15 +76,15 @@ namespace Subterfuge.Agents
         /// <summary>
         /// Whether this agent is role-blocked (prevented from acting).
         /// </summary>
-        public bool IsBlocked => Blocker?.IsAlive == true;
+        public bool IsBlocked => Blocker?.IsActive == true;
         /// <summary>
         /// Whether this agent is being protected from death.
         /// </summary>
-        public bool IsProtected => Protector != null && Protector.IsAlive && !Protector.IsBlocked;
+        public bool IsProtected => Protector != null && Protector.IsActive && !Protector.IsBlocked;
         /// <summary>
         /// Whether this agent is able to act.
         /// </summary>
-        public bool CanAct => IsAlive && !(RequiresTarget && Target is null) && !IsBlocked;
+        public bool CanAct => IsActive && !(RequiresTarget && Target is null) && !IsBlocked;
 
         /// <summary>
         /// If true, the <see cref="Protector"/> will be killed instead of this agent.
@@ -98,7 +98,7 @@ namespace Subterfuge.Agents
         {
             Codename = GameService.GenerateUniqueCodename();
             Gender = (Gender)GameService.Random.Next(2);
-            IsAlive = true;
+            IsActive = true;
             Reset();
         }
 
@@ -223,7 +223,7 @@ namespace Subterfuge.Agents
         /// <param name="killer">The agent killing this agent.</param>
         protected void Kill(Agent killer)
         {
-            IsAlive = false;
+            IsActive = false;
             Killer = killer;
             WasKilled = true;
         }

--- a/Subterfuge/Agents/Android.cs
+++ b/Subterfuge/Agents/Android.cs
@@ -21,7 +21,7 @@ namespace Subterfuge.Agents
         {
             if (GameService.Random.NextDouble() <= CHANCE_TO_ATTACK)
             {
-                List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.IsAlive && a is not Mastermind).ToList();
+                List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.IsActive && a is not Mastermind).ToList();
 
                 if (validTargets.Any())
                 {
@@ -33,7 +33,7 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive && Target != this)
+            if (Target.IsActive && Target != this)
                 Target.Attack(this);
         }
     }

--- a/Subterfuge/Agents/Assassin.cs
+++ b/Subterfuge/Agents/Assassin.cs
@@ -11,7 +11,7 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive && Target != this && Target is not Mastermind or Android or Sleeper)
+            if (Target.IsActive && Target != this && Target is not Mastermind or Android or Sleeper)
                 Target.Attack(this);
         }
 

--- a/Subterfuge/Agents/Convoy.cs
+++ b/Subterfuge/Agents/Convoy.cs
@@ -26,6 +26,11 @@ namespace Subterfuge.Agents
                 };
         }
 
+        protected override string GetReportBriefAction()
+        {
+            return $" {Target.Codename} was visited by: {string.Join(", ", Target.Visitors)}";
+        }
+
         protected override ReportType GetReportType()
         {
             if (Target == this || IsBlocked)

--- a/Subterfuge/Agents/Convoy.cs
+++ b/Subterfuge/Agents/Convoy.cs
@@ -11,7 +11,7 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive)
+            if (Target.IsActive)
                 Target.Protect(this, true);
         }
 

--- a/Subterfuge/Agents/Cutout.cs
+++ b/Subterfuge/Agents/Cutout.cs
@@ -20,7 +20,7 @@ namespace Subterfuge.Agents
 
         public override void SelectTarget(AgentList agents)
         {
-            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.IsAlive).ToList();
+            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.IsActive).ToList();
 
             if (validTargets.Any())
             {

--- a/Subterfuge/Agents/Drudge.cs
+++ b/Subterfuge/Agents/Drudge.cs
@@ -13,13 +13,13 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive && Target != this)
+            if (Target.IsActive && Target != this)
                 Target.Attack(this);
         }
 
         public override void SelectTarget(AgentList agents)
         {
-            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsAlive).ToList();
+            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsActive).ToList();
 
             if (validTargets.Any())
             {

--- a/Subterfuge/Agents/Fabricator.cs
+++ b/Subterfuge/Agents/Fabricator.cs
@@ -18,7 +18,7 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive && Target != this)
+            if (Target.IsActive && Target != this)
                 Target.Frame(this);
         }
 
@@ -27,14 +27,14 @@ namespace Subterfuge.Agents
             List<Agent> validTargets = agents.ShuffledList.Where(a => 
                 a != this && 
                 a.Allegiance != Allegiance.Enemy && 
-                a.IsAlive &&
+                a.IsActive &&
                 a != agents[nameof(Mastermind)].Target &&
                 a != agents[nameof(Drudge)].Target &&
                 a is not Sleeper // Sleeper is a valid target but it's treated differently
             ).ToList();
 
             // Give the Sleeper a higher chance of being selected than the others
-            if (agents[nameof(Sleeper)].IsAlive && GameService.Random.NextDouble() <= CHANCE_TO_TARGET_SLEEPER)
+            if (agents[nameof(Sleeper)].IsActive && GameService.Random.NextDouble() <= CHANCE_TO_TARGET_SLEEPER)
             {
                 Target = agents[nameof(Sleeper)];
                 IsActing = true;

--- a/Subterfuge/Agents/Hacker.cs
+++ b/Subterfuge/Agents/Hacker.cs
@@ -64,7 +64,7 @@ namespace Subterfuge.Agents
 
         protected HackerReportType GetHackerReportType()
         {
-            if (!Target.IsAlive || IsBlocked)
+            if (!Target.IsActive || IsBlocked)
                 return HackerReportType.Blocked;
             else if(Target is Android)
                 return HackerReportType.Android;

--- a/Subterfuge/Agents/Interrogator.cs
+++ b/Subterfuge/Agents/Interrogator.cs
@@ -100,7 +100,7 @@ namespace Subterfuge.Agents
 
         protected InterrogatorReportType GetInterrogatorReportType()
         {
-            if (!Target.IsAlive || IsBlocked)
+            if (!Target.IsActive || IsBlocked)
             {
                 return InterrogatorReportType.Blocked;
             }

--- a/Subterfuge/Agents/Interrogator.cs
+++ b/Subterfuge/Agents/Interrogator.cs
@@ -72,7 +72,7 @@ namespace Subterfuge.Agents
                 {
                     InterrogatorReportType.Android_Assassin_Sentry => " the Android, the Assassin, or the Sentry.",
                     InterrogatorReportType.Convoy_Drudge => " the Convoy or the Drudge.",
-                    InterrogatorReportType.Cutout_Mastermind_Swallow => " the Cutout, the Mastermind, or the Swallow/Raven.",
+                    InterrogatorReportType.Cutout_Mastermind_Swallow => " the Cut-out, the Mastermind, or the Swallow/Raven.",
                     InterrogatorReportType.Fabricator_Hacker => " the Fabricator or the Hacker.",
                     InterrogatorReportType.Marshal_Saboteur => " the Marshal or the Saboteur.",
                     InterrogatorReportType.Medic_Sleeper => " the Medic or the Sleeper.",

--- a/Subterfuge/Agents/Marshal.cs
+++ b/Subterfuge/Agents/Marshal.cs
@@ -19,7 +19,7 @@ namespace Subterfuge.Agents
                 Target.Target = this;
                 Target.IsActing = true;
             }
-            else if (Target.IsAlive && Target != this)
+            else if (Target.IsActive && Target != this)
             {
                 Target.Block(this);
                 Target.Protect(this);

--- a/Subterfuge/Agents/Mastermind.cs
+++ b/Subterfuge/Agents/Mastermind.cs
@@ -18,23 +18,23 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive && Target != this)
+            if (Target.IsActive && Target != this)
                 Target.Attack(this);
         }
 
         public override void SelectTarget(AgentList agents)
         {
             Agent drudge = agents[nameof(Drudge)];
-            if (!drudge.IsAlive && GameService.Random.NextDouble() <= CHANCE_TO_ATTACK)
+            if (!drudge.IsActive && GameService.Random.NextDouble() <= CHANCE_TO_ATTACK)
             {
-                if (drudge.Target?.IsAlive == true)
+                if (drudge.Target?.IsActive == true)
                 {
                     Target = drudge.Target;
                     IsActing = true;
                 }
                 else
                 {
-                    List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsAlive).ToList();
+                    List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsActive).ToList();
 
                     if (validTargets.Any())
                     {

--- a/Subterfuge/Agents/Medic.cs
+++ b/Subterfuge/Agents/Medic.cs
@@ -19,7 +19,7 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive && Target != this)
+            if (Target.IsActive && Target != this)
                 Target.Protect(this, false);
         }
 
@@ -48,7 +48,7 @@ namespace Subterfuge.Agents
 
         protected MedicReportType GetMedicReportType()
         {
-            if (!Target.IsAlive || IsBlocked)
+            if (!Target.IsActive || IsBlocked)
                 return MedicReportType.Blocked;
             else if (Target.WasAttacked)
                 return MedicReportType.Attacked;

--- a/Subterfuge/Agents/PlayerAgent.cs
+++ b/Subterfuge/Agents/PlayerAgent.cs
@@ -6,6 +6,10 @@ namespace Subterfuge.Agents
     public abstract class PlayerAgent : Agent
     {
         public override Allegiance Allegiance => Allegiance.Ally;
+        /// <summary>
+        /// Whether this agent deserted this round.
+        /// </summary>
+        public bool Deserted { get; set; }
 
         /// <summary>
         /// Removes this agent from the game.
@@ -13,6 +17,7 @@ namespace Subterfuge.Agents
         public void Desert()
         {
             IsActive = false;
+            Deserted = true;
         }
 
         /// <summary>
@@ -46,6 +51,12 @@ namespace Subterfuge.Agents
                     ReportType.SelfIdentify => $" they are {Codename}.",
                     _ => throw new NotImplementedException()
                 };
+        }
+
+        public override void Reset()
+        {
+            Deserted = false;
+            base.Reset();
         }
 
         /// <summary>

--- a/Subterfuge/Agents/PlayerAgent.cs
+++ b/Subterfuge/Agents/PlayerAgent.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Subterfuge.Enums;
 
 namespace Subterfuge.Agents
@@ -9,6 +6,14 @@ namespace Subterfuge.Agents
     public abstract class PlayerAgent : Agent
     {
         public override Allegiance Allegiance => Allegiance.Ally;
+
+        /// <summary>
+        /// Removes this agent from the game.
+        /// </summary>
+        public void Desert()
+        {
+            IsActive = false;
+        }
 
         /// <summary>
         /// Gets this agent's full report for the round.

--- a/Subterfuge/Agents/Saboteur.cs
+++ b/Subterfuge/Agents/Saboteur.cs
@@ -13,13 +13,13 @@ namespace Subterfuge.Agents
 
         protected override void Act()
         {
-            if (Target.IsAlive && Target != this)
+            if (Target.IsActive && Target != this)
                 Target.Block(this);
         }
 
         public override void SelectTarget(AgentList agents)
         {
-            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsAlive).ToList();
+            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsActive).ToList();
 
             if (validTargets.Any())
             {

--- a/Subterfuge/Agents/Sleeper.cs
+++ b/Subterfuge/Agents/Sleeper.cs
@@ -18,7 +18,7 @@ namespace Subterfuge.Agents
 
         public override void SelectTarget(AgentList agents)
         {
-            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsAlive).ToList();
+            List<Agent> validTargets = agents.ShuffledList.Where(a => a != this && a.Allegiance == Allegiance.Ally && a.IsActive).ToList();
             if (validTargets.Any())
                 Target = validTargets[GameService.Random.Next(validTargets.Count)];
 

--- a/Subterfuge/Agents/Swallow.cs
+++ b/Subterfuge/Agents/Swallow.cs
@@ -26,7 +26,7 @@ namespace Subterfuge.Agents
                 Target.Target = this;
                 Target.IsActing = true;
             }
-            else if (Target.IsAlive && Target != this)
+            else if (Target.IsActive && Target != this)
             {
                 Target.Block(this);
                 Target.Protect(this);

--- a/Subterfuge/GameService.cs
+++ b/Subterfuge/GameService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Subterfuge.Agents;
 using Subterfuge.Enums;
@@ -41,7 +42,7 @@ namespace Subterfuge
         public int Round { get; protected set; }
         public double Morale { get; protected set; }
         public AgentList Agents { get; protected set; }
-        public List<List<string>> Evidence { get; protected set; } = new();
+        public ObservableCollection<List<string>> Evidence { get; protected set; } = new();
 
         private static List<string> _generatedCodenames = new();
 
@@ -92,7 +93,7 @@ namespace Subterfuge
             }
 
             #region Populate initial evidence
-            while (Evidence.Count < Round - 1)
+            while (Evidence.Count < Round)
                 Evidence.Add(new List<string>());
 
             foreach (Agent agent in Agents.PlayerAgents.Where(a => a.IsActing))
@@ -123,7 +124,7 @@ namespace Subterfuge
         public void EndRound()
         {
             // This block is meant as a fail-safe and should never actually be hit.
-            while (Evidence.Count < Round - 1)
+            while (Evidence.Count < Round)
                 Evidence.Add(new List<string>());
 
             foreach (Agent agent in Agents.OrderedList)
@@ -156,10 +157,10 @@ namespace Subterfuge
                 if (Random.NextDouble() < CHANCE_TO_DESERT)
                 {
                     List<Agent> possibleDeserters = Agents.ShuffledList.Where(a => a is PlayerAgent && a.IsActive).ToList();
-                    PlayerAgent deserter = (PlayerAgent)possibleDeserters[Random.Next(possibleDeserters.Count)]
+                    PlayerAgent deserter = (PlayerAgent)possibleDeserters[Random.Next(possibleDeserters.Count)];
                     deserter.Desert();
 
-                    while (Evidence.Count < Round - 1)
+                    while (Evidence.Count < Round)
                         Evidence.Add(new List<string>());
 
                     Evidence[Round - 1].Add($"The {deserter.Name} deserted.");

--- a/Subterfuge/GameService.cs
+++ b/Subterfuge/GameService.cs
@@ -41,6 +41,13 @@ namespace Subterfuge
 
         public int Round { get; protected set; }
         public double Morale { get; protected set; }
+        public string MoraleLevel => Morale switch
+        {
+            <= -15 => "Panicked",
+            <= -10 => "Alarmed",
+            <= -5 => "Uneasy",
+            _ => "Calm"
+        };
         public AgentList Agents { get; protected set; }
         public ObservableCollection<List<string>> Evidence { get; protected set; } = new();
 
@@ -132,6 +139,8 @@ namespace Subterfuge
                 if (agent.WasExecuted)
                 {
                     Evidence[Round - 1].Add($"You executed the {agent.Name} ({agent.Codename}).");
+                    if (agent is Sleeper && agent.Target is not null && agent.Target.WasKilled)
+                        Evidence[Round - 1].Add($"The {agent.Name} killed the {agent.Target.Name} ({agent.Target.Codename}).");
 
                     if (agent is Cutout)
                         Morale -= 10;
@@ -152,6 +161,8 @@ namespace Subterfuge
             ++Round;
             Agents.OrderedList.ForEach(a => a.Reset());
 
+            // Determine if an agent will desert
+            // this block mus come after the agents have reset
             if (Morale < DESERTION_MORALE_THRESHOLD)
             {
                 if (Random.NextDouble() < CHANCE_TO_DESERT)

--- a/Subterfuge/Pages/Game/AgentSelector.razor
+++ b/Subterfuge/Pages/Game/AgentSelector.razor
@@ -4,7 +4,7 @@
 <Grid NumColumns="2" Items="Game.Agents.PlayerAgents">
     <ItemTemplate>
         @{
-            bool disabled = !context.IsAlive || (!context.IsActing && NumSelected >= GameService.MAX_AGENT_SELECTIONS);
+            bool disabled = !context.IsActive || (!context.IsActing && NumSelected >= GameService.MAX_AGENT_SELECTIONS);
             <div class="btn-group-toggle" data-toggle="buttons">
                 <label class="btn btn-block btn-outline-dark btn-height-double @(context.IsActing ? "active" : disabled ? "disabled" : "")">
                     <input type="checkbox"
@@ -35,7 +35,7 @@
 
         if (isChecked)
         {
-            if (agent.IsAlive && NumSelected < GameService.MAX_AGENT_SELECTIONS)
+            if (agent.IsActive && NumSelected < GameService.MAX_AGENT_SELECTIONS)
             {
                 if (agent.RequiresTarget)
                     Nav.NavigateTo($"/selecttarget/{agent.GetType().Name}");

--- a/Subterfuge/Pages/Game/ExecutionResults.razor
+++ b/Subterfuge/Pages/Game/ExecutionResults.razor
@@ -15,7 +15,7 @@
             <div class="row">
                 <div class="col-12">
                     <p>Just before you pull the trigger, you hear a "click" and an explosion in the background. The @nameof(Sleeper) smiles at you menacingly.</p>
-                    <p>@ExecutedAgent.Target.Codename has died. @ExecutedAgent.Target.Gender.ToCommonPronoun() was the @ExecutedAgent.Name.</p>
+                    <p>@ExecutedAgent.Target.Codename has died. @ExecutedAgent.Target.Gender.ToCommonPronoun() was the @ExecutedAgent.Target.Name.</p>
                 </div>
             </div>
         }

--- a/Subterfuge/Pages/Game/ExecutionSelector.razor
+++ b/Subterfuge/Pages/Game/ExecutionSelector.razor
@@ -7,7 +7,7 @@
         @{
             string modalId = $"modal-execute-{context.Name}";
 
-            if (context.IsAlive)
+            if (context.IsActive)
             {
                 <Modal id="@modalId"
                        ConfirmButtonText="Confirm"
@@ -18,12 +18,12 @@
             }
         }
         <button type="button"
-                class="btn btn-block btn-dark @(context.IsAlive ? "btn-height-double" : "")"
+                class="btn btn-block btn-dark @(context.IsActive ? "btn-height-double" : "")"
                 data-toggle="modal"
                 data-target="#@modalId"
-                disabled="@(!context.IsAlive)">
+                disabled="@(!context.IsActive)">
             @context.Codename
-            @if (!context.IsAlive)
+            @if (!context.IsActive)
             {
                 <br />
                 <span class="muted">@context.Name</span>

--- a/Subterfuge/Pages/Game/Results.razor
+++ b/Subterfuge/Pages/Game/Results.razor
@@ -7,7 +7,7 @@
         <h3>Reports</h3>
         <div class="reports row">
             <div class="col-12">
-                @foreach (PlayerAgent agent in Game.Agents.PlayerAgents.Where(a => a.IsAlive && a.IsActing))
+                @foreach (PlayerAgent agent in Game.Agents.PlayerAgents.Where(a => a.IsActive && a.IsActing))
                 {
                     <h4>@agent.Name's Report</h4>
                     <p>@agent.GetReport()</p>

--- a/Subterfuge/Pages/Game/Results.razor
+++ b/Subterfuge/Pages/Game/Results.razor
@@ -1,5 +1,5 @@
 ﻿@page "/results"
-@inherits RoundEnder
+@inherits GameEnder
 
 <br />
 <div class="row justify-content-center">
@@ -39,6 +39,10 @@
 @code {
     protected void Continue()
     {
+        // Redirect to the game over screen if the game is over
+        RedirectIfGameOver();
+
+        // Otherwise, continue the round
         Nav.NavigateTo("/execute");
     }
 }

--- a/Subterfuge/Pages/Game/TargetSelector.razor
+++ b/Subterfuge/Pages/Game/TargetSelector.razor
@@ -4,11 +4,11 @@
 <Grid NumColumns="2" Items="Game.Agents.ShuffledList">
     <ItemTemplate>
         <button type="button"
-                class="btn btn-block btn-dark @(context.IsAlive ? "btn-height-double" : "")"
+                class="btn btn-block btn-dark @(context.IsActive ? "btn-height-double" : "")"
                 @onclick="() => SetTarget(context)"
-                disabled="@(!context.IsAlive)">
+                disabled="@(!context.IsActive)">
             @context.Codename
-            @if (!context.IsAlive)
+            @if (!context.IsActive)
             {
                 <br />
                 <span class="muted">@context.Name</span>
@@ -35,7 +35,7 @@
 
     protected void SetTarget(Agent target)
     {
-        if (target.IsAlive)
+        if (target.IsActive)
         {
             Agent.IsActing = true;
             Agent.Target = target;

--- a/Subterfuge/Pages/Index.razor
+++ b/Subterfuge/Pages/Index.razor
@@ -15,6 +15,6 @@
 {
     void StartGame()
     {
-        Nav.NavigateTo("/selectagents");
+        Nav.NavigateTo("/newround");
     }
 }

--- a/Subterfuge/Pages/NewRound.razor
+++ b/Subterfuge/Pages/NewRound.razor
@@ -1,0 +1,31 @@
+﻿@page "/newround"
+@inherits GameEnder
+@inject GameService Game
+@using System.Threading.Tasks
+
+
+<div class="row justify-content-center">
+    <div class="col center-contents-horizontal">
+        <h2>Day @Game.Round</h2>
+        <p>Morale: @Game.MoraleLevel</p>
+
+        @foreach (PlayerAgent agent in Game.Agents.PlayerAgents.Where(a => a.Deserted))
+        {
+            <p>Disilliusioned by your leadership, the @agent.Name abandons @agent.Gender.ToPossessivePronoun().ToLower() post.</p>
+        }
+    </div>
+</div>
+
+@code {
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        Task.Delay(5000).ContinueWith(t =>
+        {
+            RedirectIfGameOver();
+
+            Nav.NavigateTo("/selectagents");
+        });
+
+        return base.OnAfterRenderAsync(firstRender);
+    }
+}

--- a/Subterfuge/Shared/GameEnder.razor
+++ b/Subterfuge/Shared/GameEnder.razor
@@ -1,0 +1,20 @@
+﻿@inject GameService Game
+
+@code {
+    /// <summary>
+    /// Redirects to the game over screen if the game is over. Otherwise, does nothing.
+    /// </summary>
+    protected void RedirectIfGameOver()
+    {
+        if (!Game.Agents[nameof(Android)].IsActive && !Game.Agents[nameof(Drudge)].IsActive && !Game.Agents[nameof(Mastermind)].IsActive)
+        {
+            // Win
+            Nav.NavigateTo("/gameover/true");
+        }
+        else if (!Game.Agents.OrderedList.Any(a => a.Allegiance == Allegiance.Ally && a.IsActive))
+        {
+            // Lose
+            Nav.NavigateTo("/gameover/false");
+        }
+    }
+}

--- a/Subterfuge/Shared/GameLayout.razor
+++ b/Subterfuge/Shared/GameLayout.razor
@@ -64,11 +64,16 @@
 
     protected override void OnInitialized()
     {
-        EvidenceIndex = Game.Evidence.Count - 1;
+        Game.Evidence.CollectionChanged += Evidence_CollectionChanged;
     }
 
     protected void ChangeEvidencePage(int change)
     {
         EvidenceIndex = Math.Clamp(EvidenceIndex + change, 0, Game.Evidence.Count - 1);
+    }
+
+    private void Evidence_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        EvidenceIndex = Game.Evidence.Count - 1;
     }
 }

--- a/Subterfuge/Shared/RoundEnder.razor
+++ b/Subterfuge/Shared/RoundEnder.razor
@@ -12,6 +12,6 @@
 
         // If not, end the round and keep playing
         Game.EndRound();
-        Nav.NavigateTo("/selectagents");
+        Nav.NavigateTo("/newround");
     }
 }

--- a/Subterfuge/Shared/RoundEnder.razor
+++ b/Subterfuge/Shared/RoundEnder.razor
@@ -3,12 +3,12 @@
 @code {
     protected void EndRound()
     {
-        if (!Game.Agents[nameof(Android)].IsAlive && !Game.Agents[nameof(Drudge)].IsAlive && !Game.Agents[nameof(Mastermind)].IsAlive)
+        if (!Game.Agents[nameof(Android)].IsActive && !Game.Agents[nameof(Drudge)].IsActive && !Game.Agents[nameof(Mastermind)].IsActive)
         {
             // Win
             Nav.NavigateTo("/gameover/true");
         }
-        else if (!Game.Agents.OrderedList.Any(a => a.Allegiance == Allegiance.Ally && a.IsAlive))
+        else if (!Game.Agents.OrderedList.Any(a => a.Allegiance == Allegiance.Ally && a.IsActive))
         {
             // Lose
             Nav.NavigateTo("/gameover/false");

--- a/Subterfuge/Shared/RoundEnder.razor
+++ b/Subterfuge/Shared/RoundEnder.razor
@@ -1,23 +1,17 @@
-﻿@inject GameService Game
+﻿@inherits GameEnder
+@inject GameService Game
 
 @code {
+    /// <summary>
+    /// Redirects to the game over screen if the game is over. Otherwise, ends the round and starts a new round.
+    /// </summary>
     protected void EndRound()
     {
-        if (!Game.Agents[nameof(Android)].IsActive && !Game.Agents[nameof(Drudge)].IsActive && !Game.Agents[nameof(Mastermind)].IsActive)
-        {
-            // Win
-            Nav.NavigateTo("/gameover/true");
-        }
-        else if (!Game.Agents.OrderedList.Any(a => a.Allegiance == Allegiance.Ally && a.IsActive))
-        {
-            // Lose
-            Nav.NavigateTo("/gameover/false");
-        }
-        else
-        {
-            // Keep playing
-            Game.EndRound();
-            Nav.NavigateTo("/selectagents");
-        }
+        // Redirect to the game over screen if the game is over
+        RedirectIfGameOver();
+
+        // If not, end the round and keep playing
+        Game.EndRound();
+        Nav.NavigateTo("/selectagents");
     }
 }


### PR DESCRIPTION
- Added morale system.
    - Morale decreases whenever a player agent dies.
    - Morale increases whenever an enemy dies.
    - Morale decreases a lot if the Cut-out is executed.
    - If morale gets low enough, player agents may start to desert.
    - Renamed IsAlive to IsActive to reflect agents who are both alive and have not deserted.
- Fixed a bug that somehow got introduced that caused the evidence modal to bork.
- Fixed multiple bugs related to the Sleeper's interaction.

